### PR TITLE
Overriding default Nginx configuration

### DIFF
--- a/config/nginx.default
+++ b/config/nginx.default
@@ -1,0 +1,47 @@
+server {
+    #proxy_cache cache;
+    #proxy_cache_valid 200 1s;
+    listen 8080;
+    listen [::]:8080;
+    root /home/site/wwwroot/public;
+    index  index.php index.html index.htm;
+    server_name  example.com www.example.com;
+
+    location / {
+        index  index.php index.html index.htm hostingstart.html;
+        try_files $uri /index.php$is_args$args;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /html/;
+    }
+
+    # Disable .git directory
+    location ~ /\.git {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Add locations of phpmyadmin here.
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param QUERY_STRING $query_string;
+        fastcgi_intercept_errors on;
+        fastcgi_connect_timeout         300;
+        fastcgi_send_timeout           3600;
+        fastcgi_read_timeout           3600;
+        fastcgi_buffer_size 128k;
+        fastcgi_buffers 4 256k;
+        fastcgi_busy_buffers_size 256k;
+        fastcgi_temp_file_write_size 256k;
+    }
+}


### PR DESCRIPTION
The default Nginx configuration of Linux Azure App Service sets the document root to /home/site/wwwroot but with many applications, this needs to be redefined into a subdirectory of the project. This configuration overrides these settings.